### PR TITLE
Dockerの設定

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,21 +5,24 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
+  username: root
+  password: root
+  host: 127.0.0.1
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: mitsumori_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: mitsumori_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: mitsumori_production
+  password: <%= ENV['MITSUMORI_DATABASE_PASSWORD'] %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: postgres:latest
     restart: always
     ports:
-      - 5432:5432
+      - 3000:3000
     environment:
       POSTGRES_USER: root
       POSTGRES_PASSWORD: root


### PR DESCRIPTION
# 概要
## タスク内容 
   1. postgres gemの導入
   　Gemfileで`gem 'pg'` →bundle install
   2. Dockerでpostgresの導入
       Gemfileを指定してdocker-compose.ymlファイルを作成する→内容をコピペ（version情報、database情報、ユーザー、PWなど）→`$ docker-compose up -d `(VSコードのターミナル上でコンテナを立ち上げる）
   3. database.yml の調整
　　アダプター、ユーザー、パスワード、ホスト番号の確認
   4. ` $ bundle exec rails db:create` を実行し、データベースを作る
   5. Table Plusを使ってデータベースの接続を行う　※S-19.20
   6. ` $ bundle exec rails s` を実行し、 `http://localhost:3000 `にアクセスしてRailsアプリが立ち上がる事を確認
　　
### 以下エラーが出た

> Webpacker configuration file not found /Users/yokotanaoki/git/wonderful_editor/config/webpacker.yml. Please run rails webpacker:install Error: No such file or directory 

　「webpackerの設定ファイルが見つからない。webpacker:install を実行してください。」と言っている。
　　 node.jsの確認`$ node --version`⇨V16.2.0 / yarnの確認 `$ yarn -v` ⇨1.22.4  インストール済みOK

        ` $ bundle exec rails webpacker:install ` ⇨ 開通‼︎

 ### $ docker-compose up -d でエラー発生
```
yokotanaoki@naoking mitsumori % docker-compose build
database uses an image, skipping
yokotanaoki@naoking mitsumori % docker-compose up -d
Recreating mitsumori_database_1 ... 
Recreating mitsumori_database_1 ... error

ERROR: for mitsumori_database_1  Cannot start service database: driver failed programming external connectivity on endpoint mitsumori_database_1 (8cda2fb364130ad42b692cfd5d1944945910e66b3d3167ece42b88d208b8de47): Bind for 0.0.0.0:5432 failed: port is already allocated

ERROR: for database  Cannot start service database: driver failed programming external connectivity on endpoint mitsumori_database_1 (8cda2fb364130ad42b692cfd5d1944945910e66b3d3167ece42b88d208b8de47): Bind for 0.0.0.0:5432 failed: port is already allocated
ERROR: Encountered errors while bringing up the project.
yokotanaoki@naoking mitsumori % docker-compose down 
Removing mitsumori_database_1              ... done
Removing 9c7827e24ec7_mitsumori_database_1 ... done
Removing network mitsumori_default
yokotanaoki@naoking mitsumori % docker-compose up -d
Creating network "mitsumori_default" with the default driver
Creating mitsumori_database_1 ... 
Creating mitsumori_database_1 ... error

ERROR: for mitsumori_database_1  Cannot start service database: driver failed programming external connectivity on endpoint mitsumori_database_1 (f6944764b5b775b5f5b002fa73170fbf66a7fb7f4377f6ee838f13293a8245fc): Bind for 0.0.0.0:5432 failed: port is already allocated

ERROR: for database  Cannot start service database: driver failed programming external connectivity on endpoint mitsumori_database_1 (f6944764b5b775b5f5b002fa73170fbf66a7fb7f4377f6ee838f13293a8245fc): Bind for 0.0.0.0:5432 failed: port is already allocated
ERROR: Encountered errors while bringing up the project.
yokotanaoki@naoking mitsumori % docker-compose ps   
        Name                      Command               State     Ports
-----------------------------------------------------------------------
mitsumori_database_1   docker-entrypoint.sh postgres   Exit 128        
yokotanaoki@naoking mitsumori % docker-compose up -d
Recreating mitsumori_database_1 ... done
yokotanaoki@naoking mitsumori % docker-compose ps   
        Name                      Command              State                   Ports                 
-----------------------------------------------------------------------------------------------------
mitsumori_database_1   docker-entrypoint.sh postgres   Up      0.0.0.0:3000->3000/tcp,:::3000->3000/t
                                                               cp, 5432/tcp                          
yokotanaoki@naoking mitsumori % bundle exec rails db:create
Created database 'mitsumori_development'
Created database 'mitsumori_test'
```
 - $ docker-compose build →　`skipping`
 - $ docker-compose up -d →　ドライバーがエンドポイントmitsumori_database_1（f6944764b5b775b5f5b002fa73170fbf66a7fb7f4377f6ee838f13293a8245fc）の外部接続のプログラミングに失敗しました。0.0.0.0:5432へのバインドが失敗しました：ポートはすでに割り当てられています。
 - $ docker-compose ps で状態を確認→　StateがExit128 とのことで動いておらず。
 - docker-compose.ymlのポート番号を変更→$ docker-compose up -d 実行→OK
 -  $ docker-compose ps で状態を確認→　StateがUp で動いていることを確認

