### PR TITLE
モデル名とカラム名の変更とモデル追加

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Client < ApplicationRecord
+end

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-class Company < ApplicationRecord
+class Supplier < ApplicationRecord
 end

--- a/db/migrate/20211021211503_change_companies_to_clients.rb
+++ b/db/migrate/20211021211503_change_companies_to_clients.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# rubocop警告対応の為、記述
+class ChangeCompaniesToClients < ActiveRecord::Migration[6.1]
+  def change
+    rename_table :companies, :clients
+  end
+end

--- a/db/migrate/20211021215522_rename_company_name_column_to_clients.rb
+++ b/db/migrate/20211021215522_rename_company_name_column_to_clients.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# rubocop警告対応の為、記述
+class RenameCompanyNameColumnToClients < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :clients, :company_name, :client_name
+  end
+end

--- a/db/migrate/20211021220655_create_suppliers.rb
+++ b/db/migrate/20211021220655_create_suppliers.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# rubocop警告対応の為、記述
+class CreateSuppliers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :suppliers do |t|
+      t.string :supplier_name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,18 +12,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_211_012_091_635) do # rubocop:disable all
+ActiveRecord::Schema.define(version: 20_211_021_220_655) do  # rubocop:disable all
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
-  create_table 'comments', force: :cascade do |t|
-    t.text 'body'
+  create_table 'clients', force: :cascade do |t|
+    t.string 'client_name'
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
   end
 
-  create_table 'companies', force: :cascade do |t|
-    t.string 'company_name'
+  create_table 'comments', force: :cascade do |t|
+    t.text 'body'
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
   end
@@ -65,6 +65,12 @@ ActiveRecord::Schema.define(version: 20_211_012_091_635) do # rubocop:disable al
   create_table 'sales', force: :cascade do |t|
     t.decimal 'sell_price'
     t.money 'sell_mold', scale: 2
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+  end
+
+  create_table 'suppliers', force: :cascade do |t|
+    t.string 'supplier_name'
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
   end

--- a/spec/factories/suppliers.rb
+++ b/spec/factories/suppliers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :supplier do
+    supplier_name { 'MyString' }
+  end
+end

--- a/spec/models/supplier_spec.rb
+++ b/spec/models/supplier_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Supplier, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# 概要
## 会社モデルと顧客と仕入先に分ける為、モデルを分割
  - `company`テーブルを`client`に変更
  -  `bundle exec rails g migration change_companies_to_clients`　※ dbのファイルは複数形
  -  上のコマンドで作られたマイグレーションの中身を記述
  -  `rename_table :companies, :clients` def changeの直下
  -  app/modelの変更：手動でファイルを変更 ※モデルは単数形
  - `bundle exec rails db:migrate`
 
## カラム名変更方法
 - migrationファイルを作成
 - `$ bundle exec rails g migration rename_company_name_column_to_clients` ※モデル名は複数形
 - 生成されたファイルにchangeメソッドを追加し、そこに変更したいカラム名を追加する。
```
# rubocop警告対応の為、記述
class RenameCompanyNameColumnToClients < ActiveRecord::Migration[6.1]
  def change
    rename_column :clients, :company_name, :client_name
  end
end
```
 - `$bundle exec rails db:migrate` DBに反映

## Supplier モデルを追加
 - カラム名：supplier_name:  string 