### PR TITLE
DBの編集_RDBの設定、カラムの変更と追加など

### DIFF
--- a/app/models/quotation.rb
+++ b/app/models/quotation.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Quotation < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  validates :company_id, presence: true, uniqueness: true
+  has_many :quotations
 end

--- a/db/migrate/20211024200741_rename_email_column_to_users.rb
+++ b/db/migrate/20211024200741_rename_email_column_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# rubocop警告対応の為、記述
+class RenameEmailColumnToUsers < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :users, :email, :name
+  end
+end

--- a/db/migrate/20211024201929_add_company_id_to_users.rb
+++ b/db/migrate/20211024201929_add_company_id_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# rubocop警告対応の為、記述
+class AddCompanyIdToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :company_id, :string
+  end
+end

--- a/db/migrate/20211024211849_add_user_to_quotations.rb
+++ b/db/migrate/20211024211849_add_user_to_quotations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# rubocop警告対応の為、記述
+class AddUserToQuotations < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :quotations, :user, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20211024212042_add_material_to_quotations.rb
+++ b/db/migrate/20211024212042_add_material_to_quotations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# rubocop警告対応の為、記述
+class AddMaterialToQuotations < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :quotations, :material, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20211024212237_add_client_to_quotations.rb
+++ b/db/migrate/20211024212237_add_client_to_quotations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# rubocop警告対応の為、記述
+class AddClientToQuotations < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :quotations, :client, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20211024212559_add_quotation_to_comments.rb
+++ b/db/migrate/20211024212559_add_quotation_to_comments.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# rubocop警告対応の為、記述
+class AddQuotationToComments < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :comments, :quotation, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20211024212705_add_quotation_to_sales.rb
+++ b/db/migrate/20211024212705_add_quotation_to_sales.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# rubocop警告対応の為、記述
+class AddQuotationToSales < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :sales, :quotation, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20211024212817_add_quotation_to_costs.rb
+++ b/db/migrate/20211024212817_add_quotation_to_costs.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# rubocop警告対応の為、記述
+class AddQuotationToCosts < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :costs, :quotation, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20211024220140_add_email_to_users.rb
+++ b/db/migrate/20211024220140_add_email_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# rubocop警告対応の為、記述
+class AddEmailToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_211_021_220_655) do  # rubocop:disable all
+ActiveRecord::Schema.define(version: 20_211_024_220_140) do # rubocop:disable all
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
@@ -26,6 +26,8 @@ ActiveRecord::Schema.define(version: 20_211_021_220_655) do  # rubocop:disable a
     t.text 'body'
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
+    t.bigint 'quotation_id', null: false
+    t.index ['quotation_id'], name: 'index_comments_on_quotation_id'
   end
 
   create_table 'costs', force: :cascade do |t|
@@ -33,6 +35,8 @@ ActiveRecord::Schema.define(version: 20_211_021_220_655) do  # rubocop:disable a
     t.money 'cost_mold', scale: 2
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
+    t.bigint 'quotation_id', null: false
+    t.index ['quotation_id'], name: 'index_costs_on_quotation_id'
   end
 
   create_table 'materials', force: :cascade do |t|
@@ -60,6 +64,12 @@ ActiveRecord::Schema.define(version: 20_211_021_220_655) do  # rubocop:disable a
     t.binary 'drawing'
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
+    t.bigint 'user_id', null: false
+    t.bigint 'material_id', null: false
+    t.bigint 'client_id', null: false
+    t.index ['client_id'], name: 'index_quotations_on_client_id'
+    t.index ['material_id'], name: 'index_quotations_on_material_id'
+    t.index ['user_id'], name: 'index_quotations_on_user_id'
   end
 
   create_table 'sales', force: :cascade do |t|
@@ -67,6 +77,8 @@ ActiveRecord::Schema.define(version: 20_211_021_220_655) do  # rubocop:disable a
     t.money 'sell_mold', scale: 2
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
+    t.bigint 'quotation_id', null: false
+    t.index ['quotation_id'], name: 'index_sales_on_quotation_id'
   end
 
   create_table 'suppliers', force: :cascade do |t|
@@ -76,14 +88,23 @@ ActiveRecord::Schema.define(version: 20_211_021_220_655) do  # rubocop:disable a
   end
 
   create_table 'users', force: :cascade do |t|
-    t.string 'email', default: '', null: false
+    t.string 'name', default: '', null: false
     t.string 'encrypted_password', default: '', null: false
     t.string 'reset_password_token'
     t.datetime 'reset_password_sent_at'
     t.datetime 'remember_created_at'
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
-    t.index ['email'], name: 'index_users_on_email', unique: true
+    t.string 'company_id'
+    t.string 'email'
+    t.index ['name'], name: 'index_users_on_name', unique: true
     t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
   end
+
+  add_foreign_key 'comments', 'quotations'
+  add_foreign_key 'costs', 'quotations'
+  add_foreign_key 'quotations', 'clients'
+  add_foreign_key 'quotations', 'materials'
+  add_foreign_key 'quotations', 'users'
+  add_foreign_key 'sales', 'quotations'
 end


### PR DESCRIPTION
# 概要
## テーブルカラムの変更
 - 変更したいカラム名：company_id、変更後のカラム名：registration_id、テーブル名：users
 - `bundle exec rails g migration rename_registration_id_column_to_users` rename_[カラム名]_column_to_[テーブル名] カラム名変更のマイグレーションファイルを作成
 - 生成されたファイルを編集
 - ` rename_column :users, :company_id, :registration_id`
 - `bundle exec rails db:migrate ` SQLを確認
　
## テーブルカラムの追加
 - `bundle exec rails g migration AddCompanyIdToUsers company_id:string`
 - `bundle exec rails db:migrate ` SQLを確認
 - `bundle exec rails g migration AddEmailToUsers email:string ` 中身作成時にバリデーションエラーが出た為、再作成
 -  `bundle exec rails db:migrate ` SQLを確認

## RDBを作成：外部キー（foreign_key)を作成してテーブル同士を紐づける
### 今回は1対多のみ実装
 - `bundle exec rails g migration AddUserToQuotations user:references`→`bundle exec rails db:migrate`
 - `bundle exec rails g migration AddClientToQuotations client:references`→`bundle exec rails db:migrate`等々
 - "1"側のモデルに`has_many`をつける→app/models/user.rb `has_many :quotations`　※モデルは複数形
 - "多"側のモデルに`belongs_to`をつける→app/models/quotation.rb `belongs_to :user` ※モデルは単数系

## テーブルの中身を入れる
 - `bundle exec rails c`  pryを立ち上げる
 - `User.create!(name: "hoge", company_id:"A1025", email: "hoge@example.com" )`
 - SQLでテーブルを確認
 
## Rubocopの警告
 - migrationファイルに`# rubocop警告対応の為、記述`のコメントを入れる
 - schema.rbのActiverecordの欄に`# rubocop:disable all`のコメントを入れる
 　※毎回同じエラーの為、備忘録として

